### PR TITLE
Upgrade to mkdocs-material 8.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mike==1.1.2
-mkdocs-material==7.3.1
+mkdocs-material==8.1.1

--- a/v1/mkdocs.yml
+++ b/v1/mkdocs.yml
@@ -31,13 +31,15 @@ theme:
   favicon: img/favicon.png
   logo: img/logo.png
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to light mode
   features:
     - navigation.tabs
@@ -53,11 +55,13 @@ extra:
 
 # Useful markdown extensions
 markdown_extensions:
+  - meta
   - admonition
   - footnotes
   - pymdownx.details
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
 
 
 # Plugins providing additional functionality for this theme

--- a/v1/overrides/main.html
+++ b/v1/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
-{% block announce %}
+{% block outdated %}
   <strong>Notice: HSE 1.x is no longer actively maintained</strong>
 {% endblock %}

--- a/v2/mkdocs.yml
+++ b/v2/mkdocs.yml
@@ -28,13 +28,15 @@ theme:
   favicon: img/favicon.png
   logo: img/logo.png
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to light mode
   features:
     - navigation.tabs
@@ -50,11 +52,13 @@ extra:
 
 # Useful markdown extensions
 markdown_extensions:
+  - meta
   - admonition
   - footnotes
   - pymdownx.details
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Signed-off-by: Steve Moyer <6214608+smoyergh@users.noreply.github.com>

Upgrade to mkdocs-material 8.x, and more specifically 8.1.1 due to issues in earlier versions.  As documented in the release, there are a few minor tweaks that need to be made to mkdocs.yml in going from 7.x to 8.x.

Made a few other tweaks in the process:

- Detect light/dark-mode system preference
- Change light/dark-mode icon from switch on/off to sun/moon, which is more commonly used
- Replace the HSE 1.x announce block with an outdated block, which was previously only available to "insiders"



