### PR TITLE
Use meson setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir --fatal-meson-warnings -Dwerror=true
+          meson setup builddir --fatal-meson-warnings -Dwerror=true
 
       - name: Build
         run: |


### PR DESCRIPTION
Leaving out the setup command is deprecated in Meson master.

Signed-off-by: Tristan Partin <tpartin@micron.com>